### PR TITLE
Version 0.4.7

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Version 0.4.7
+- Added the `CrashTrainingTabReady` hook, which fires when the downtime tab is ready. Example usage:
+```js
+Hooks.on(`CrashTrainingTabReady`, (app, html, data) => {
+  console.log("Crash's 5e Downtime Tracking | Downtime tab ready!");
+});
+```
+
 ## Version 0.4.6
 Improvements:
 - Changed the way activity data is updated behind the scenes so things don't explode for no good reason. Special thanks to Ethck#6879 for slogging through it with me.

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
 	"name": "5e-training",
 	"title": "Crash's 5e Downtime Tracking",
 	"description": "Adds a section to the character sheet to keep track of downtime activity progression. Track proficiency training, spell scribing, and anything else you can think of.",
-	"version": "0.4.6",
+	"version": "0.4.7",
 	"author": "CRASH1115#2944",
 	"minimumCoreVersion": "0.6.6",
 	"compatibleCoreVersion": "0.7.3",
@@ -28,5 +28,5 @@
 	],
 	"url": "https://github.com/crash1115/5e-training",
   "manifest": "https://raw.githubusercontent.com/crash1115/5e-training/master/module.json",
-	"download": "https://github.com/crash1115/5e-training/releases/download/v0.4.6/5e-training.zip"
+	"download": "https://github.com/crash1115/5e-training/releases/download/v0.4.7/5e-training.zip"
 }

--- a/training.js
+++ b/training.js
@@ -508,6 +508,8 @@ async function addTrainingTab(app, html, data) {
 
   }
 
+  //Tab is ready
+  Hooks.call(`CrashTrainingTabReady`, app, html, data);
 }
 
 // Calculates the progress value of an activity and logs the change to the progress
@@ -658,4 +660,8 @@ Hooks.on(`renderActorSheet`, (app, html, data) => {
       app._tabs[0].activate("training");
     }
   });
+});
+
+Hooks.on(`CrashTrainingTabReady`, (app, html, data) => {
+  console.log("Crash's 5e Downtime Tracking | Downtime tab ready!");
 });


### PR DESCRIPTION
Added the `CrashTrainingTabReady` hook, which fires when the downtime tab is ready. Example usage:
```js
Hooks.on(`CrashTrainingTabReady`, (app, html, data) => {
  console.log("Crash's 5e Downtime Tracking | Downtime tab ready!");
});
```